### PR TITLE
feat: add forgot-password page and email-based password reset flow

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,17 @@
+# Server
+PORT=5000
+
+# MongoDB
+MONGO_URL=mongodb://127.0.0.1:27017/school_website
+
+# JWT
+JWT_SECRET=your_jwt_secret_key_here
+
+# Optional: Email (for password reset in production)
+# If not set, reset links are logged to the console (development mode)
+EMAIL_SERVICE=gmail
+EMAIL_USER=your_email@gmail.com
+EMAIL_PASS=your_gmail_app_password
+
+# Optional: Frontend URL (used in reset email link)
+FRONTEND_URL=http://localhost:5173

--- a/backend/controllers/Authcontroller.js
+++ b/backend/controllers/Authcontroller.js
@@ -1,6 +1,8 @@
 const User = require("../models/User");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
+const crypto = require("crypto");
+const nodemailer = require("nodemailer");
 
 exports.register = async (req, res) => {
   try {
@@ -66,6 +68,91 @@ exports.login = async (req, res) => {
       token,
       user: { id: user._id, name: user.name, email: user.email },
     });
+  } catch (error) {
+    res.status(500).json({ message: "Server Error", error: error.message });
+  }
+};
+
+exports.forgotPassword = async (req, res) => {
+  try {
+    const { email } = req.body;
+    const user = await User.findOne({ email });
+
+    // Return same message regardless of whether email exists (prevents enumeration)
+    if (!user) {
+      return res.status(200).json({ message: "If that email is registered, a reset link has been sent." });
+    }
+
+    const rawToken = crypto.randomBytes(32).toString("hex");
+    const hashedToken = crypto.createHash("sha256").update(rawToken).digest("hex");
+
+    user.resetPasswordToken = hashedToken;
+    user.resetPasswordExpires = Date.now() + 3600000; // 1 hour
+    await user.save();
+
+    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+    const resetUrl = `${frontendUrl}/#/reset-password?token=${rawToken}`;
+
+    if (process.env.EMAIL_USER && process.env.EMAIL_PASS) {
+      const transporter = nodemailer.createTransport({
+        service: process.env.EMAIL_SERVICE || "gmail",
+        auth: { user: process.env.EMAIL_USER, pass: process.env.EMAIL_PASS },
+      });
+
+      await transporter.sendMail({
+        from: `"EduStream Academy" <${process.env.EMAIL_USER}>`,
+        to: user.email,
+        subject: "EduStream Academy – Password Reset Request",
+        html: `
+          <p>Hi ${user.name},</p>
+          <p>We received a request to reset your password. Click the link below — it expires in <strong>1 hour</strong>.</p>
+          <p><a href="${resetUrl}">${resetUrl}</a></p>
+          <p>If you did not request this, you can safely ignore this email.</p>
+          <br/>
+          <p>— EduStream Academy</p>
+        `,
+      });
+    } else {
+      // In development without email config, log the link so it can be tested
+      console.log(`[DEV] Password reset link for ${email}: ${resetUrl}`);
+    }
+
+    res.status(200).json({ message: "If that email is registered, a reset link has been sent." });
+  } catch (error) {
+    res.status(500).json({ message: "Server Error", error: error.message });
+  }
+};
+
+exports.resetPassword = async (req, res) => {
+  try {
+    const { token, password } = req.body;
+
+    if (!token || !password) {
+      return res.status(400).json({ message: "Token and new password are required." });
+    }
+
+    if (password.length < 6) {
+      return res.status(400).json({ message: "Password must be at least 6 characters." });
+    }
+
+    const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
+
+    const user = await User.findOne({
+      resetPasswordToken: hashedToken,
+      resetPasswordExpires: { $gt: Date.now() },
+    });
+
+    if (!user) {
+      return res.status(400).json({ message: "Reset link is invalid or has expired. Please request a new one." });
+    }
+
+    const salt = await bcrypt.genSalt(10);
+    user.password = await bcrypt.hash(password, salt);
+    user.resetPasswordToken = undefined;
+    user.resetPasswordExpires = undefined;
+    await user.save();
+
+    res.status(200).json({ message: "Password reset successfully. You can now log in with your new password." });
   } catch (error) {
     res.status(500).json({ message: "Server Error", error: error.message });
   }

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -15,6 +15,8 @@ const userSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
+    resetPasswordToken: String,
+    resetPasswordExpires: Date,
   },
   { timestamps: true },
 );

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,8 @@
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.4.1",
-        "mysql": "^2.18.1"
+        "mysql": "^2.18.1",
+        "nodemailer": "^8.0.10"
       },
       "devDependencies": {
         "nodemon": "^3.1.11"
@@ -1048,6 +1049,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.4.1",
-    "mysql": "^2.18.1"
+    "mysql": "^2.18.1",
+    "nodemailer": "^8.0.10"
   },
   "devDependencies": {
     "nodemon": "^3.1.11"

--- a/backend/routes/Auth.js
+++ b/backend/routes/Auth.js
@@ -1,8 +1,10 @@
 const express = require("express");
 const router = express.Router();
-const { register, login } = require("../controllers/Authcontroller");
+const { register, login, forgotPassword, resetPassword } = require("../controllers/Authcontroller");
 
 router.post("/register", register);
 router.post("/login", login);
+router.post("/forgot-password", forgotPassword);
+router.post("/reset-password", resetPassword);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,10 @@ import Scholarship from "./pages/Scholarship";
 import Gallery from "./pages/Gallery";
 import Student from "./pages/Student";
 import DownloadProspectus from "./pages/DownloadProspectus";
+import Login from "./pages/Login";
+import Register from "./pages/Register";
+import ForgotPassword from "./pages/ForgotPassword";
+import ResetPassword from "./pages/ResetPassword";
 
 /**
  * ScrollToTop ensures that every time a user navigates to a new page,
@@ -63,7 +67,13 @@ const App = () => {
             <Route path="/admissions/scholarship" element={<Scholarship />} />
             <Route path="/prospectus" element={<DownloadProspectus />} /> 
             <Route path="/student" element={<Student />} />
-            
+            <Route path="/login" element={<Login />} />
+            <Route path="/login/:role" element={<Login />} />
+            <Route path="/register" element={<Register />} />
+            <Route path="/register/:role" element={<Register />} />
+            <Route path="/forgot-password" element={<ForgotPassword />} />
+            <Route path="/reset-password" element={<ResetPassword />} />
+
             {/* Catch-all route for 404 Page Not Found */}
             <Route path="*" element={<NotFound />} />
             

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -1,0 +1,87 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import API from "../utils/axios";
+
+const ForgotPassword = () => {
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    setMessage("");
+    setLoading(true);
+
+    try {
+      const { data } = await API.post("/auth/forgot-password", { email });
+      setMessage(data.message);
+    } catch (err) {
+      setError(err.response?.data?.message || "Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 px-4">
+      <div className="max-w-md w-full bg-white rounded-xl shadow-lg p-8">
+
+        <h2 className="text-3xl font-bold text-center text-gray-800 mb-2">
+          Forgot Password
+        </h2>
+        <p className="text-center text-gray-500 text-sm mb-8">
+          Enter your registered email and we'll send you a reset link.
+        </p>
+
+        {message && (
+          <div className="bg-green-50 border border-green-200 text-green-700 rounded-lg px-4 py-3 mb-6 text-sm text-center">
+            {message}
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-600 rounded-lg px-4 py-3 mb-6 text-sm text-center">
+            {error}
+          </div>
+        )}
+
+        {!message && (
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Email Address
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                required
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-semibold py-3 rounded-lg transition-all active:scale-95"
+            >
+              {loading ? "Sending..." : "Send Reset Link"}
+            </button>
+          </form>
+        )}
+
+        <p className="text-center text-sm text-gray-500 mt-6">
+          Remembered it?{" "}
+          <Link to="/login" className="text-blue-600 hover:underline font-medium">
+            Back to Sign In
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -1,0 +1,130 @@
+import React, { useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import API from "../utils/axios";
+
+const ResetPassword = () => {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    setMessage("");
+
+    if (password !== confirm) {
+      return setError("Passwords do not match.");
+    }
+
+    setLoading(true);
+    try {
+      const { data } = await API.post("/auth/reset-password", { token, password });
+      setMessage(data.message);
+    } catch (err) {
+      setError(err.response?.data?.message || "Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-100 px-4">
+        <div className="max-w-md w-full bg-white rounded-xl shadow-lg p-8 text-center">
+          <h2 className="text-2xl font-bold text-gray-800 mb-4">Invalid Link</h2>
+          <p className="text-gray-500 mb-6">
+            This reset link is missing or malformed. Please request a new one.
+          </p>
+          <Link
+            to="/forgot-password"
+            className="inline-block bg-blue-600 text-white font-semibold px-6 py-3 rounded-lg hover:bg-blue-700 transition"
+          >
+            Request New Link
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 px-4">
+      <div className="max-w-md w-full bg-white rounded-xl shadow-lg p-8">
+
+        <h2 className="text-3xl font-bold text-center text-gray-800 mb-2">
+          Reset Password
+        </h2>
+        <p className="text-center text-gray-500 text-sm mb-8">
+          Enter your new password below.
+        </p>
+
+        {message && (
+          <div className="bg-green-50 border border-green-200 text-green-700 rounded-lg px-4 py-3 mb-6 text-sm text-center">
+            {message}{" "}
+            <Link to="/login" className="font-semibold underline">
+              Sign In
+            </Link>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-600 rounded-lg px-4 py-3 mb-6 text-sm text-center">
+            {error}
+          </div>
+        )}
+
+        {!message && (
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                New Password
+              </label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="At least 6 characters"
+                required
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Confirm New Password
+              </label>
+              <input
+                type="password"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                placeholder="Repeat your new password"
+                required
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-semibold py-3 rounded-lg transition-all active:scale-95"
+            >
+              {loading ? "Resetting..." : "Reset Password"}
+            </button>
+          </form>
+        )}
+
+        <p className="text-center text-sm text-gray-500 mt-6">
+          <Link to="/forgot-password" className="text-blue-600 hover:underline font-medium">
+            Request a new link
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
## Related Issue
  Closes #43

  ## Description
  The login page has a "Forgot password?" link pointing to `/forgot-password`
  but the page didn't exist — clicking it gave a 404 and users had no way to recover
  their password.
  
  Added the full reset flow — email form, reset page, backend endpoints with 1-hour
  expiry.   
  In dev, the reset link prints to the backend console so no SMTP setup is needed to
  test.
  
  ## Screenshots
<img width="1038" height="696" alt="Screenshot 2026-06-03 at 12 12 51 PM" src="https://github.com/user-attachments/assets/fbaf0c72-32e4-49ea-aac0-dd5c6cc25f9c" />
<img width="1036" height="698" alt="Screenshot 2026-06-03 at 12 13 09 PM" src="https://github.com/user-attachments/assets/6688fa26-2d9d-4c79-ac33-10aa401d4f21" />


  ## Checklist
  - [x] Tested in dev server (`npm run dev`)
  - [x] No console errors
  - [x] Screenshots attached