### PR TITLE
fix: standardize notice schema and notice creation flow

### DIFF
--- a/backend/controllers/teacherController.js
+++ b/backend/controllers/teacherController.js
@@ -17,14 +17,19 @@ const getMyNotices = async (req, res) => {
 
 const postNotice = async (req, res) => {
   try {
-    const { title, message, targetClass } = req.body;
-    if (!title || !message) {
-      return res.status(400).json({ success: false, message: 'Title and message are required.' });
+    const { title, content, targetClass } = req.body;
+
+    if (!title || !content) {
+      return res.status(400).json({
+        success: false,
+        message: 'Title and content are required.'
+      });
     }
 
     const notice = await Notice.create({
       title,
-      message,
+      category: 'Teacher',
+      content,
       targetClass: targetClass || 'All',
       postedBy: req.user._id,
       teacherName: req.user.name,

--- a/backend/models/Notice.js
+++ b/backend/models/Notice.js
@@ -16,11 +16,6 @@ const noticeSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
-    message: {
-      type: String,
-      required: [true, 'Message is required'],
-      trim: true,
-    },
     targetClass: {
       type: String,
       default: 'All',
@@ -28,7 +23,6 @@ const noticeSchema = new mongoose.Schema(
     postedBy: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'User',
-      required: true,
     },
     teacherName: {
       type: String,

--- a/frontend/src/components/teacher/NoticePanel.jsx
+++ b/frontend/src/components/teacher/NoticePanel.jsx
@@ -3,7 +3,7 @@ import api from '../../utils/axios';
 
 const NoticePanel = () => {
   const [notices, setNotices] = useState([]);
-  const [form, setForm] = useState({ title: '', message: '', targetClass: '' });
+  const [form, setForm] = useState({ title: '', content: '', targetClass: '' });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -21,8 +21,8 @@ const NoticePanel = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!form.title || !form.message) {
-      setError('Title and message are required.');
+    if (!form.title || !form.content) {
+      setError('Title and content are required.');
       return;
     }
     setLoading(true);
@@ -30,7 +30,7 @@ const NoticePanel = () => {
     try {
       await api.post('/teacher/notices', form);
       setSuccess('Notice posted successfully!');
-      setForm({ title: '', message: '', targetClass: '' });
+      setForm({ title: '', content: '', targetClass: '' });
       fetchNotices();
     } catch (err) {
       setError(err.response?.data?.message || 'Failed to post notice.');
@@ -63,9 +63,9 @@ const NoticePanel = () => {
           className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <textarea
-          placeholder="Notice message *"
-          value={form.message}
-          onChange={e => setForm({ ...form, message: e.target.value })}
+          placeholder="Notice content *"
+          value={form.content}
+          onChange={e => setForm({ ...form, content: e.target.value })}
           rows={3}
           className="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
@@ -95,7 +95,7 @@ const NoticePanel = () => {
             <div key={notice._id} className="flex items-start justify-between bg-gray-50 rounded-xl p-4">
               <div>
                 <p className="font-semibold text-gray-800 text-sm">{notice.title}</p>
-                <p className="text-gray-500 text-xs mt-1">{notice.message}</p>
+                <p className="text-gray-500 text-xs mt-1">{notice.content}</p>
                 {notice.targetClass && (
                   <span className="inline-block mt-2 text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full">
                     {notice.targetClass}


### PR DESCRIPTION
## Summary

This PR resolves inconsistencies between the Notice schema, notice creation flows, and frontend notice rendering.

### Changes Made

* Removed the duplicate `message` field from the Notice schema.
* Standardized notice body content to use the `content` field across the application.
* Updated teacher notice creation to use `content` and provide a default `category`.
* Updated teacher notice rendering to use `notice.content`.
* Made `postedBy` optional to support auto-seeded/system notices that are created without an authenticated user.

### Result

All notice creation flows, schema validation, and frontend rendering now use a consistent notice structure, reducing schema mismatches and improving maintainability.

Closes #93
