### PR TITLE
feat: add environment variable validation on server startup

### DIFF
--- a/backend/config/validateEnv.js
+++ b/backend/config/validateEnv.js
@@ -1,0 +1,48 @@
+const validateEnv = () => {
+  const errors = [];
+  const warnings = [];
+
+  // ─── Required Variables ───────────────────────────────────────────
+  const requiredVars = {
+    MONGO_URL: process.env.MONGO_URL,
+    JWT_SECRET: process.env.JWT_SECRET,
+  };
+
+  const placeholders = [
+    "your_jwt_secret_key_here",
+    "your_email@gmail.com",
+    "your_gmail_app_password",
+  ];
+
+  for (const [key, value] of Object.entries(requiredVars)) {
+    if (!value || placeholders.includes(value)) {
+      errors.push(`❌ Missing or placeholder value: ${key}`);
+    }
+  }
+
+  // ─── Optional Variables ───────────────────────────────────────────
+  const optionalVars = ["EMAIL_SERVICE", "EMAIL_USER", "EMAIL_PASS", "FRONTEND_URL"];
+
+  for (const key of optionalVars) {
+    const value = process.env[key];
+    if (!value || placeholders.includes(value)) {
+      warnings.push(`⚠️  Optional var not set: ${key}`);
+    }
+  }
+
+  // ─── Output ───────────────────────────────────────────────────────
+  if (warnings.length > 0) {
+    console.warn("\n[ENV] Warnings:");
+    warnings.forEach((w) => console.warn(" ", w));
+  }
+
+  if (errors.length > 0) {
+    console.error("\n[ENV] Critical errors — server cannot start:");
+    errors.forEach((e) => console.error(" ", e));
+    process.exit(1);
+  }
+
+  console.log("✅ Environment variables validated successfully.\n");
+};
+
+module.exports = validateEnv;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,7 +3,7 @@ const dotenv = require("dotenv");
 const cors = require("cors");
 const mongoose = require("mongoose");
 const path = require("path");
-
+const validateEnv = require("./config/validateEnv.js");
 const authRoutes = require("./routes/Auth");
 const inquiryRoutes = require("./routes/inquiryRoutes.js");
 const noticeRoutes = require("./routes/noticeRoutes.js");
@@ -14,7 +14,7 @@ dotenv.config();
 const app = express();
 app.use(cors());
 app.use(express.json());
-
+validateEnv();
 // routes
 app.use("/api/auth", authRoutes);
 app.use("/api/inquiries", inquiryRoutes);


### PR DESCRIPTION
## Description
Implements a `validateEnv()` function in `config/validateEnv.js` that runs on server startup before DB connection or route setup.

## Changes Made
- Added `config/validateEnv.js` with validation logic
- Called `validateEnv()` at the top of `server.js` before DB/routes

## Validation Logic
- **Required vars** (`MONGO_URL`, `JWT_SECRET`) → if missing or placeholder: logs clear error + `process.exit(1)`
- **Optional vars** (`EMAIL_SERVICE`, `EMAIL_USER`, `EMAIL_PASS`, `FRONTEND_URL`) → if missing: logs warning, server continues

## Affected Area
- [x] Other: Server startup / environment config

Closes #99

<!SSOC26!>