### PR TITLE
feat: add global React error boundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hasError: false,
+      error: null,
+    };
+  }
+
+  static getDerivedStateFromError(error) {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error("Error Boundary caught an error:", error);
+    console.error("Component Stack:", errorInfo);
+  }
+
+  handleRetry = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+    });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex flex-col items-center justify-center px-4 text-center">
+          <h1 className="text-3xl font-bold mb-4">
+            Something went wrong
+          </h1>
+
+          <p className="text-gray-600 mb-6">
+            An unexpected error occurred. Please try again.
+          </p>
+
+          <div className="flex gap-4">
+            <button
+              onClick={this.handleRetry}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg"
+            >
+              Retry
+            </button>
+
+            <button
+              onClick={() => window.location.reload()}
+              className="px-4 py-2 border rounded-lg"
+            >
+              Reload Page
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,3 +1,4 @@
+import ErrorBoundary from "./components/ErrorBoundary";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
@@ -8,10 +9,12 @@ import App from "./App.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
+  <ErrorBoundary>
     <ThemeProvider>
       <AuthProvider>
         <App />
       </AuthProvider>
     </ThemeProvider>
-  </StrictMode>
+  </ErrorBoundary>
+</StrictMode>
 );


### PR DESCRIPTION
## Summary

Implemented a reusable React Error Boundary to improve frontend resilience and prevent application crashes caused by unhandled component errors.

## Changes Made

* Added a reusable `ErrorBoundary` component in `src/components/ErrorBoundary.jsx`
* Implemented error handling using:

  * `getDerivedStateFromError`
  * `componentDidCatch`
* Added a user-friendly fallback UI
* Added recovery actions:

  * Retry
  * Reload Page
* Added console logging for debugging purposes
* Wrapped the application with `ErrorBoundary` in `src/main.jsx`

## Testing

* Intentionally triggered a React runtime error to verify Error Boundary behavior
* Confirmed fallback UI is displayed instead of a blank screen
* Verified error details are logged to the browser console
* Verified project builds successfully using `npm run build`

## Acceptance Criteria Checklist

* [x] Errors within React component trees are caught by the Error Boundary
* [x] Users see a fallback UI instead of a blank screen
* [x] Error details are logged for debugging
* [x] Application remains resilient against unexpected component failures
* [x] Implementation follows existing React project structure and coding standards

closes #105